### PR TITLE
Add feature to keep date user has searched for in filter

### DIFF
--- a/app/data_mapper_setup.rb
+++ b/app/data_mapper_setup.rb
@@ -5,4 +5,4 @@ require_relative 'models/space'
 
 DataMapper.setup(:default, ENV['DATABASE_URL'] || "postgres://localhost/randbnb_#{ENV['RACK_ENV']}")
 DataMapper.finalize
-DataMapper.auto_migrate!
+DataMapper.auto_upgrade!

--- a/app/rand_bnb.rb
+++ b/app/rand_bnb.rb
@@ -49,7 +49,7 @@ class RandBnb < Sinatra::Base
         flash.now[:error] = "Chosen date not available"
       end
     else
-      @spaces = Space.all
+      @spaces = Space.all(:available_from.lte => Date.today, :available_to.gte => Date.today)
     end
     erb :dashboard
   end

--- a/app/views/dashboard.erb
+++ b/app/views/dashboard.erb
@@ -11,7 +11,8 @@ Welcome <%= @current_user.email %>
 </form>
 
 <form action="space/filter" method="post">
-  <label>Search Availability</label><input type="date" name='search_availability' value='<%=Date.today%>'>
+  <label>Search Availability</label><input type="date" name='search_availability' value='<%= @search_availability %>'>
+
   <input type="submit" value="Search">
 </form>
 

--- a/spec/features/spaces_spec.rb
+++ b/spec/features/spaces_spec.rb
@@ -79,7 +79,16 @@ feature 'dashboard shows spaces' do
     add_space_not_today
     click_button "Search"
     expect(page).not_to have_text("Jenna's room")
-
   end
+
+  scenario "filter keeps date user has searched for after search is complete" do
+    sign_up
+    add_space
+    fill_in "search_availability", with: "2016-12-18"
+    click_button "Search"
+    click_button "Search"
+    expect(page).not_to have_content("Comfy room")
+  end
+
 
 end


### PR DESCRIPTION
fixes #45
If a user visits the dashboard page for the first time, "Search Availability" field is defaulted to today's date.
If a user has searched for a specific date, "Search Availability" field stays at the date the user has searched for.