### PR TITLE
Amend booking and booking page when a request is approved or rejected

### DIFF
--- a/app/rand_bnb.rb
+++ b/app/rand_bnb.rb
@@ -196,11 +196,34 @@ class RandBnb < Sinatra::Base
         @my_spaces << space.id
       end
     end
-    p @my_spaces
     @all_requests = Booking.all
     erb :'request/requests'
   end
 
+  get '/bookings' do
+    @bookings_made = Booking.all(user_id: current_user.id)
+    p @bookings_made
+    @my_spaces = []
+    Space.all(user_id: current_user.id).each do |space|
+      if space.user_id = current_user.id
+        @my_spaces << space.id
+      end
+    end
+    @all_bookings = Booking.all
+    erb :'booking/bookings'
+  end
+
+  post '/booking_accept' do
+    booking = Booking.all(id: params[:id])
+    booking.update(:booking_confirmed => true)
+    redirect '/dashboard'
+  end
+
+  post '/booking_reject' do
+    booking = Booking.all(id: params[:id])
+    booking.destroy
+    redirect '/dashboard'
+  end
 
   # start the server if ruby file executed directly
   run! if app_file == $0

--- a/app/views/booking/bookings.erb
+++ b/app/views/booking/bookings.erb
@@ -1,0 +1,32 @@
+<ul id="bookings_made">
+  Bookings Made:
+  <br>
+  <% @bookings_made.map do |booking| %>
+    <% if booking.booking_confirmed == true %>
+      Booking number: <%= booking.id %>
+      Booking date: <%= booking.booking_date %>
+      Space name: <% space = Space.all(id: booking.space_id) %>
+      <% space.map do |space| %> <%= space.name %> <% end %>
+      <br>
+      <% end %>
+  <% end %>
+  <br>
+</ul>
+
+<ul id="bookings_received">
+  Bookings Received:
+  <br>
+  <% @all_bookings.each do |booking| %>
+    <% if @my_spaces.include?(booking.space_id) %>
+      <% if booking.booking_confirmed == true %>
+        <li id='<%=booking.id%>'>
+          Booking number: <%= booking.id %>
+          Booking date: <%= booking.booking_date %>
+          Space name: <% space = Space.all(id: booking.space_id) %>
+          <% space.map do |space| %> <%= space.name %> <% end %>
+        </li>
+      <% end %>
+    <% end %>
+    <br>
+  <% end %>
+</ul>

--- a/app/views/dashboard.erb
+++ b/app/views/dashboard.erb
@@ -13,11 +13,15 @@ Welcome <%= @current_user.email %>
   <input type="submit" value="My requests">
 </form>
 
+<form action="/bookings">
+  <input type="submit" value="My bookings">
+</form>
+
 <form action="space/filter" method="post">
   <label>Search Availability</label><input type="date" name='search_availability' value='<%= @search_availability %>'>
-
   <input type="submit" value="Search">
 </form>
+
 
 <ul id="spaces">
 

--- a/app/views/request/requests.erb
+++ b/app/views/request/requests.erb
@@ -3,27 +3,41 @@
   Requests Made:
   <br>
   <% @requests_made.map do |request| %>
-  <% if  request.booking_confirmed == false %>
-    Request number: <%= request.id %>
-    Booking date: <%= request.booking_date %>
-    Space name: <% space = Space.all(id: request.space_id) %>
-    <% space.map do |space| %> <%= space.name %> <% end %>
-
-    <br>
-
-  <% end %>
+    <% if request.booking_confirmed == false %>
+      Request number: <%= request.id %>
+      Booking date: <%= request.booking_date %>
+      Space name: <% space = Space.all(id: request.space_id) %>
+      <% space.map do |space| %> <%= space.name %> <% end %>
+      <br>
+    <% end %>
   <% end %>
   <br>
+</ul>
+
+<ul id="requests_received">
 
   Requests Received:
   <br>
   <% @all_requests.each do |request| %>
     <% if @my_spaces.include?(request.space_id) %>
       <% if request.booking_confirmed == false %>
-        Request number: <%= request.id %>
-        Booking date: <%= request.booking_date %>
-        Space name: <% space = Space.all(id: request.space_id) %>
-        <% space.map do |space| %> <%= space.name %> <% end %>
+        <li id='<%=request.id%>'>
+          Request number: <%= request.id %>
+          Booking date: <%= request.booking_date %>
+          Space name: <% space = Space.all(id: request.space_id) %>
+          <% space.map do |space| %> <%= space.name %> <% end %>
+
+          <form action='/booking_accept' method='post'>
+            <input type='hidden' value='<%=request.id%>' name='id'>
+            <input type='submit' value='Accept'>
+          </form>
+
+          <form action='/booking_reject' method='post'>
+            <input type='hidden' value='<%=request.id%>' name='id'>
+            <input type='submit' value='Reject'>
+          </form>
+
+        </li>
       <% end %>
     <% end %>
   <br>

--- a/app/views/space/host.erb
+++ b/app/views/space/host.erb
@@ -11,9 +11,9 @@
     Space available to: <%= space.available_to %>
     <form action='/space/edit' method="POST">
       <input type="hidden" value="<%=space.id %>" name='id'>
-      <input type="submit" value="Edit space" >
+      <input type="submit" value="Edit space">
     </form>
   </li>
   <% end %>
-  
+
 </ul>

--- a/spec/features/bookings_spec.rb
+++ b/spec/features/bookings_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+feature 'Bookings Page' do
+
+  scenario 'Once request is approved, user can see bookings made' do
+    sign_up
+    add_space
+    click_button("Sign Out")
+    sign_up2
+    make_request
+    click_button("Sign Out")
+    sign_in
+    click_button("My requests")
+    accept_request
+    click_button("My bookings")
+    expect(page).to have_content("Comfy room")
+  end
+
+  scenario 'Once request is approved, it can no longer be seen in requests' do
+    sign_up
+    add_space
+    click_button("Sign Out")
+    sign_up2
+    make_request
+    click_button("Sign Out")
+    sign_in
+    click_button("My requests")
+    accept_request
+    click_button("My requests")
+    expect(page).not_to have_content("Comfy room")
+  end
+
+  scenario 'Once request is rejected, it can no longer be seen in requests' do
+    sign_up
+    add_space
+    click_button("Sign Out")
+    sign_up2
+    make_request
+    click_button("Sign Out")
+    sign_in
+    click_button("My requests")
+    reject_request
+    click_button("My requests")
+    expect(page).not_to have_content("Comfy room")
+  end
+
+  scenario 'Once a request is rejected, it can no longer be seen in bookings' do
+    sign_up
+    add_space
+    click_button("Sign Out")
+    sign_up2
+    make_request
+    click_button("Sign Out")
+    sign_in
+    click_button("My requests")
+    reject_request
+    click_button("My bookings")
+    expect(page).not_to have_content("Comfy room")
+  end
+
+  scenario 'Once a request is rejected, it is no longer in the database' do
+    sign_up
+    add_space
+    click_button("Sign Out")
+    sign_up2
+    make_request
+    click_button("Sign Out")
+    sign_in
+    click_button("My requests")
+    expect{reject_request}.to change(Booking, :count).by(-1)
+  end
+
+end

--- a/spec/helpers/session.rb
+++ b/spec/helpers/session.rb
@@ -136,4 +136,16 @@ module SessionHelpers
     end
   end
 
+  def accept_request
+    within('li#1') do
+      click_button("Accept")
+    end
+  end
+
+  def reject_request
+    within('li#1') do
+      click_button("Reject")
+    end
+  end
+
 end


### PR DESCRIPTION
Fixes #38 
Created buttons on Request page to approve or reject a booking
Clicking approve updates the database to change booking_confirmation to true
Clicking reject removes the record from the database
Created Bookings view to show bookings made and bookings received
